### PR TITLE
Updates/fix install

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,29 @@ Additionally, wether your DE is listed above or not, you can also create and add
 
 Thus you can add support it even if not listed above (although if you'd like to see it integrated in a later version you can always make a suggestion by [oppening an issue](https://github.com/C2N14/AutomaThemely/issues)).
 
-## Getting Started
+## Getting started for Ubuntu 20.04 and above distros
+
+Inspired by [comment](https://github.com/C2N14/AutomaThemely/issues/42#issuecomment-633081574) from [jjemil749](https://github.com/jjemil749) on original repository's [Issue #42](https://github.com/C2N14/AutomaThemely/issues/42).
+
+The original package works in Ubuntu 16.04 and 18.04.
+
+For other distros (I'm on Linux Mint 20.2 Cinnamon), there's a try packaging it yourself link:
+https://github.com/C2N14/AutomaThemely/wiki/Packaging-it-yourself.
+
+1. Clone source code with `git clone`;
+2. Run code with `sudo ./.package.sh`;
+3. Install dependencies manually: `pip3 install astral schedule tzlocal wheel`;
+4. Install the resulting **no_deps** package with: `sudo dpkg -i python3.8-no_deps-automathemely_1.3.0.dev1_all.deb`;
+5. Fix the autostart problem:
+   - `automathemely.desktop` automatically gets installed to `/usr/local/share/applications` (seems wrong, it's the only .desktop there);
+   - Copy `automathemely.desktop` to `/usr/share/applications` (where it seems it should have been).
+6. Copy `automathemely.desktop` to the user's autostart folder `$HOME/.config/autostart/automathemely.desktop`;
+
+It seems to run fine. AutomaThemely autostarts and a notification pop-up informs that it applied the dark or light theme. At night, it applied the dark theme. During the day, it applied the light theme. Seems to be working fine.
+
+---
+
+## Original Getting Started
 
 ### Prerequisites
 

--- a/install_scripts/.package.sh
+++ b/install_scripts/.package.sh
@@ -6,7 +6,7 @@ if_not_dir_create () {
   fi
 }
 
-declare -a outputs=("deb" "rpm" "sh")
+declare -a outputs=("deb" "sh")
 declare -a pypacks=("astral" "requests" "tz" "tzlocal" "schedule")
 declare -a otherdeps=("python3-pip")
 declare -a python_versions=("3.8")

--- a/install_scripts/.package.sh
+++ b/install_scripts/.package.sh
@@ -9,7 +9,7 @@ if_not_dir_create () {
 declare -a outputs=("deb" "rpm" "sh")
 declare -a pypacks=("astral" "requests" "tz" "tzlocal" "schedule")
 declare -a otherdeps=("python3-pip")
-declare -a python_versions=("3.5" "3.6")
+declare -a python_versions=("3.8")
 
 declare -a original_files=(*)
 

--- a/install_scripts/postinst.sh
+++ b/install_scripts/postinst.sh
@@ -11,7 +11,7 @@ if_not_dir_create () {
 
 local_install=false
 ## CHECK FOR ROOT PRIVILEGES
-if ((${EUID:-0} || "$(id -u)")); then
+if [[ $EUID -eq 0 ]]; then
 
     if [[ -z "$SUDO_USER" ]]; then
         echo "SUDO_USER variable not found, trying to find user manually..."

--- a/install_scripts/postinst.sh
+++ b/install_scripts/postinst.sh
@@ -48,13 +48,13 @@ fi
 ## MOVE FILES TO LOCATIONS
 # Autostart on user log in
 if_not_dir_create "$autostart_path"
-cp "$packdir/installation_files/autostart.desktop" "$autostart_path/automathemely.desktop"
+cp "$packdir/lib/installation_files/autostart.desktop" "$autostart_path/automathemely.desktop"
 sed -i "s|<PACKDIR>|$packdir|g" "$autostart_path/automathemely.desktop"
 
 # Timer & service units
 if_not_dir_create "$systemd_user_path"
-cp "$packdir/installation_files/sun-times.timer" "$systemd_user_path/automathemely.timer"
-cp "$packdir/installation_files/sun-times.service" "$systemd_user_path/automathemely.service"
+cp "$packdir/lib/installation_files/sun-times.timer" "$systemd_user_path/automathemely.timer"
+cp "$packdir/lib/installation_files/sun-times.service" "$systemd_user_path/automathemely.service"
 sed -i "s|<PACKDIR>|$packdir|g" "$systemd_user_path/automathemely.service"
 
 

--- a/install_scripts/preremove.sh
+++ b/install_scripts/preremove.sh
@@ -5,7 +5,7 @@ pkill -f "autothscheduler.py"
 
 local_install=false
 ## CHECK FOR ROOT PRIVILEGES
-if ((${EUID:-0} || "$(id -u)")); then
+if [[ $EUID -eq 0 ]]; then
 
     if [[ -z "$SUDO_USER" ]]; then
         echo "SUDO_USER variable not found, trying to find user manually..."

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     url='https://github.com/C2N14/AutomaThemely',
     license='GPLv3',
     packages=['automathemely', 'automathemely.bin', 'automathemely.autoth_tools'],
-    python_requires='>=3.5',
+    python_requires='>=3.8',
     install_requires=['requests', 'astral', 'pytz', 'tzlocal', 'schedule'],
     include_package_data=True,
     package_data={


### PR DESCRIPTION
1. Solves issue with root user during installation and uninstallation;
2. Updates to python 3.8;
3. Solves these post-installation errors.

```
cp: cannot stat '/usr/local/lib/python3.8/dist-packages/automathemely/installation_files/autostart.desktop': No such file or directory
cp: cannot stat '/usr/local/lib/python3.8/dist-packages/automathemely/installation_files/sun-times.timer': No such file or directory
cp: cannot stat '/usr/local/lib/python3.8/dist-packages/automathemely/installation_files/sun-times.service': No such file or directory
```

Built app works on Linux Mint Cinnamon 20.2.